### PR TITLE
Insert first={...} argument to glossary items.

### DIFF
--- a/thesis-template/01_head/abbreviations.tex
+++ b/thesis-template/01_head/abbreviations.tex
@@ -2,4 +2,4 @@
 %% \newglossaryentry{⟨label⟩}{name={⟨key⟩}, description={⟨value⟩}}
 %%%%%%%%%%%
 
-\newglossaryentry{ann}{name={ANN},description={Artificial Neural Network}}
+\newglossaryentry{ann}{name={ANN},description={Artificial Neural Network},first={Artificial Neural Network (ANN)}}


### PR DESCRIPTION
The first argument will be displayed on first use of the glossary item. 
The user therefore does not need to manually find the first use of an abbreviation and write out the long description.
https://tex.stackexchange.com/questions/386666/how-can-i-get-the-first-use-of-a-glossary-to-show-the-full-description